### PR TITLE
Support CKCountdownButtonDelegate

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,4 +7,5 @@ target 'Tests', :exclusive => true do
 
   pod 'Specta', '~> 0.2.1'
   pod 'Expecta'
+  pod 'OCMock', '~> 3.0.2'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,11 +1,13 @@
 PODS:
   - CKCountdownButton (0.1.0)
   - Expecta (0.3.1)
+  - OCMock (3.0.2)
   - Specta (0.2.1)
 
 DEPENDENCIES:
   - CKCountdownButton (from `../`)
   - Expecta
+  - OCMock (~> 3.0.2)
   - Specta (~> 0.2.1)
 
 EXTERNAL SOURCES:
@@ -15,6 +17,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CKCountdownButton: 4405ea35eebd53bff21981514516b95e09dc7055
   Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
+  OCMock: b9836ab89d8d5e66cbe6333f93857037c310ee62
   Specta: 9141310f46b1f68b676650ff2854e1ed0b74163a
 
 COCOAPODS: 0.33.1

--- a/Example/Tests/Tests-Prefix.pch
+++ b/Example/Tests/Tests-Prefix.pch
@@ -9,6 +9,7 @@
   #define EXP_SHORTHAND
   #import <Specta/Specta.h>
   #import <Expecta/Expecta.h>
+  #import <OCMock/OCMock.h>
   #import <CKCountdownButton.h>
 
 #endif

--- a/Example/Tests/Tests.m
+++ b/Example/Tests/Tests.m
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Quanlong He. All rights reserved.
 //
 
-
 SpecBegin(InitialSpecs)
 
 describe(@"Create a new CKCountdownButton", ^{
@@ -133,6 +132,25 @@ describe(@"Reuse exist CKCountdownButton", ^{
         expect(button.titleLabel.text).after(4).to.equal(@"1");
 
         expect(button.titleLabel.text).after(5).to.equal(@"");
+    });
+});
+
+describe(@"Delegation", ^{
+    describe(@"when counted down", ^{
+
+        it(@"should invoke delegation", ^{
+            CKCountdownButton *button = [[CKCountdownButton alloc] init];;
+
+            // In a test
+            id mock = [OCMockObject mockForProtocol:@protocol(CKCountdownButtonDelegate)];
+
+            [[mock expect] countedDown:button];
+
+            button.count = 1;
+            button.delegate = mock;
+
+            [mock verifyWithDelay:1.0];
+        });
     });
 });
 

--- a/Pod/Classes/CKCountdownButton.h
+++ b/Pod/Classes/CKCountdownButton.h
@@ -8,9 +8,24 @@
 
 #import <UIKit/UIKit.h>
 
+@protocol CKCountdownButtonDelegate;
+
 @interface CKCountdownButton : UIButton
 
 // Set this property will trigger the countdown timer start
-@property (nonatomic) NSInteger count;
+@property(nonatomic) NSInteger count;
+
+// defaults to nil
+@property(nonatomic,assign) id<CKCountdownButtonDelegate> delegate;
+
+@end
+
+
+@protocol CKCountdownButtonDelegate <NSObject>
+
+@optional
+
+// Called when timer counted down
+- (void)countedDown:(CKCountdownButton *)button;
 
 @end

--- a/Pod/Classes/CKCountdownButton.m
+++ b/Pod/Classes/CKCountdownButton.m
@@ -95,6 +95,10 @@ static NSString* PLACEHOLDER = @"#";
         if ([self.normalTitle length] == 0) {
             self.titleLabel.text = @"";
         }
+
+        if (self.delegate) {
+            [self.delegate countedDown:self];
+        }
     } else {
         NSString *title = [self.countingTitle stringByReplacingOccurrencesOfString:PLACEHOLDER withString:[@(currentCount) stringValue]];
         [self setTitle:title forState:UIControlStateDisabled];


### PR DESCRIPTION
The `countedDown` delegate will be invoked when timer count down to zero.

At first, I don't know how to write a test to verify the delegation. After a lot of search, I finally implemented.

It seems that Kiki is better than Specta, because Kiwi support Mocks and Stubs but, Specta depends on other standalone modules such as OCMock.

Here is a list of user links I found
- [Mock and Stubs in several popular lib](https://github.com/jbrunton/iosdemo/wiki/Mocks)
- [Mock and Stubs in Kiwi](https://github.com/kiwi-bdd/Kiwi/wiki/Mocks-and-Stubs)
- [Mock in Specta](https://gist.github.com/orta/d3ea1b2d10e80d757550), I cannot find `Mocta` mentioned in article.
